### PR TITLE
Feature/create ubuntu 1404 instance

### DIFF
--- a/terraform/acl_rules.tf
+++ b/terraform/acl_rules.tf
@@ -1,0 +1,25 @@
+# Allow ingress from anywhere via any protocol and port
+# Restrictions by source IP are handled by the security group rules
+resource "aws_network_acl_rule" "ingress_from_anywhere_via_any_port" {
+  network_acl_id = "${aws_network_acl.vuln_acl.id}"
+  egress = false
+  protocol = "-1"
+  rule_number = 100
+  rule_action = "allow"
+  cidr_block = "0.0.0.0/0"
+  from_port = 0
+  to_port = 0
+}
+
+# Allow egress to anywhere via any protocol and port
+# Restrictions by source IP are handled by the security group rules
+resource "aws_network_acl_rule" "egress_to_anywhere_via_any_port" {
+  network_acl_id = "${aws_network_acl.vuln_acl.id}"
+  egress = true
+  protocol = "-1"
+  rule_number = 110
+  rule_action = "allow"
+  cidr_block = "0.0.0.0/0"
+  from_port = 0
+  to_port = 0
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,10 @@
+# Configure AWS
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+# The AWS account ID being used
+data "aws_caller_identity" "current" {}
+
+# The list of available AWS availability zones
+data "aws_availability_zones" "all" {}

--- a/terraform/scripts/user_ssh_setup.yml
+++ b/terraform/scripts/user_ssh_setup.yml
@@ -1,0 +1,27 @@
+#cloud-config
+
+users:
+  - name: mark.feldhousen
+    groups: [ sudo ]
+    sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
+    shell: /bin/bash
+    ssh-authorized-keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDMAreqS1aycngT1qQAsXfo7/hzt8JdSvC1bD9Sr0WpTUVWWe6WW2mYQ9fHAYJ4pPGb/Jf3h15NRMHCwsMPuFoP+9m7iebzvS47/ce1g07AOK3bf2yR12v/S9QFArgAyabqRpDz43yay2t+3IjSHxZlKKNg0nV4xiP/LRqXvzFCjZDAu5zslFH/urZ6bhHxQMywWdW0RHfWXdz+O6rGR8f1soCPw7ylwf2AzlaeCR/WnT9QiK5TG5TxrkomnliE56T0JkhldGrTldkt2NK1R9+3wF4603nQqKkcCgXFtZKk0wKc5T+Z/B/mS9LW0ayarj1V6H1i5mpscYOD33Z6HalEXd25XO31oCDt9FuA7pHOZQInTpvNODktjwkkz0Dk6i6q3b60JaviB5ECaC9bcQDfXFGVNzA/+UVtOIKOKmp7ge8n31jEEq6nklDxrVkA/7n7cKXjUTZbV5Lru+3of8lLdYCcJhcLLMDSmJbGtw7/AN55+vxj072pLs1LAUcDBlEtqq5rShUcFeFDuxl0Cs7BRab87h6nO/uIKTAb4ZNbAKt0BuKW2gzRoVjUhibMLc/loJyeZuWa67QQ8Ae76h24dPUz44Ryul/X5LHingGd3lwQMyW/0mjpVKjC0lsUsGa+J2wezsMzxr8sj9TjYzhMCURf79E6DBUO1zUuFc0kyw== mark.feldhousen
+  - name: david.redmin
+    groups: [ sudo ]
+    sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
+    shell: /bin/bash
+    ssh-authorized-keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPCUrFIDwLAZrlkzvK7rcOVYNE7vSyopGHMFZTX7YlQS david.redmin
+  - name: jeremy.frasier
+    groups: [ sudo ]
+    sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
+    shell: /bin/bash
+    ssh-authorized-keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHJkFgYx58vd/JCikIQRVmQUBNa5k1h9Z+xzM6AjZLqE jeremy.frasier
+  - name: kyle.evers
+    groups: [ sudo ]
+    sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
+    shell: /bin/bash
+    ssh-authorized-keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKY5tqMRtnZSkVPwU0X1zKA8L3RnvmhSAR/bHAtd3Vcr kyle.evers

--- a/terraform/ssh_cloud_init.tf
+++ b/terraform/ssh_cloud_init.tf
@@ -1,0 +1,16 @@
+# cloud-init commands for configuring ssh
+
+data "template_file" "user_ssh_setup" {
+  template = "${file("scripts/user_ssh_setup.yml")}"
+}
+
+data "template_cloudinit_config" "ssh_cloud_init_tasks" {
+  gzip = true
+  base64_encode = true
+
+  part {
+    filename     = "user_ssh_setup.yml"
+    content_type = "text/cloud-config"
+    content      = "${data.template_file.user_ssh_setup.rendered}"
+  }
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    encrypt = true
+    bucket = "ncats-terraform-state-storage"
+    dynamodb_table = "terraform-state-lock"
+    region = "us-east-1"
+    key = "vulnerable-instances/terraform.tfstate"
+  }
+}

--- a/terraform/ubuntu1404_ec2.tf
+++ b/terraform/ubuntu1404_ec2.tf
@@ -1,0 +1,46 @@
+data "aws_ami" "metasploitable3_ubuntu1404" {
+  filter {
+    name = "name"
+    values = [
+      "metasploitable3-ubuntu-1404-hvm-*-x86_64-ebs"
+    ]
+  }
+
+  filter {
+    name = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+
+  owners = ["${data.aws_caller_identity.current.account_id}"] # This is us
+  most_recent = true
+}
+
+# The vulnerable Ubuntu 14.04 EC2 instance
+resource "aws_instance" "vuln_ubuntu1404" {
+  ami = "${data.aws_ami.metasploitable3_ubuntu1404.id}"
+  instance_type = "t2.micro"
+  availability_zone = "${var.aws_region}${var.aws_availability_zone}"
+
+  subnet_id = "${aws_subnet.vuln_subnet.id}"
+  associate_public_ip_address = true
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 100
+    delete_on_termination = true
+  }
+
+  vpc_security_group_ids = [
+    "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  ]
+
+  user_data_base64 = "${data.template_cloudinit_config.ssh_cloud_init_tasks.rendered}"
+
+  tags = "${merge(var.tags, map("Name", "Vulnerable Ubuntu 14.04"))}"
+  volume_tags = "${merge(var.tags, map("Name", "Vulnerable Ubuntu 14.04"))}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  description = "The AWS region to deploy into (e.g. us-east-1)."
+  default = "us-east-1"
+}
+
+variable "aws_availability_zone" {
+  description = "The AWS availability zone to deploy into (e.g. a, b, c, etc.)."
+  default = "a"
+}
+
+variable "tags" {
+  type = "map"
+  description = "Tags to apply to all AWS resources created"
+  default = {}
+}
+
+# This should be overridden by a production.tfvars file,
+# most likely stored outside of version control
+variable "trusted_ingress_networks_ipv4" {
+  type = "list"
+  description = "IPv4 CIDR blocks from which to allow ingress to the bastion server"
+  default = [ "0.0.0.0/0" ]
+}
+
+variable "trusted_ingress_networks_ipv6" {
+  type = "list"
+  description = "IPv6 CIDR blocks from which to allow ingress to the bastion server"
+  default = [ "::/0" ]
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,59 @@
+# The vulnerable VPC
+resource "aws_vpc" "vuln_vpc" {
+  cidr_block = "10.10.10.0/28"
+
+  tags = "${merge(var.tags, map("Name", "Vulnerable VPC"))}"
+}
+
+# Vulnerable (only) subnet of the VPC
+resource "aws_subnet" "vuln_subnet" {
+  vpc_id = "${aws_vpc.vuln_vpc.id}"
+  cidr_block = "10.10.10.0/28"
+  availability_zone = "${var.aws_region}${var.aws_availability_zone}"
+
+  depends_on = [
+    "aws_internet_gateway.vuln_igw"
+  ]
+
+  tags = "${merge(var.tags, map("Name", "Vulnerable Subnet"))}"
+}
+
+# The internet gateway for the VPC
+resource "aws_internet_gateway" "vuln_igw" {
+  vpc_id = "${aws_vpc.vuln_vpc.id}"
+
+  tags = "${merge(var.tags, map("Name", "Vulnerable IGW"))}"
+}
+
+# Default route table for VPC, which routes all external traffic
+# through the internet gateway
+resource "aws_default_route_table" "vuln_default_route_table" {
+  default_route_table_id = "${aws_vpc.vuln_vpc.default_route_table_id}"
+
+  tags = "${merge(var.tags, map("Name", "Vulnerable Route Table"))}"
+}
+
+# Default route: Route all external traffic through the internet
+# gateway
+resource "aws_route" "vuln_default_route_external_traffic_through_internet_gateway" {
+  route_table_id = "${aws_default_route_table.vuln_default_route_table.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id = "${aws_internet_gateway.vuln_igw.id}"
+}
+
+# ACL for the vulnerable (only) subnet
+resource "aws_network_acl" "vuln_acl" {
+  vpc_id = "${aws_vpc.vuln_vpc.id}"
+  subnet_ids = [
+    "${aws_subnet.vuln_subnet.id}"
+  ]
+
+  tags = "${merge(var.tags, map("Name", "Vulnerable ACL"))}"
+}
+
+# Security group for the vulnerable Ubuntu 14.04 instance
+resource "aws_security_group" "vuln_ubuntu1404_sg" {
+  vpc_id = "${aws_vpc.vuln_vpc.id}"
+
+  tags = "${merge(var.tags, map("Name", "Vulnerable Ubuntu 14.04"))}"
+}

--- a/terraform/vuln_ubuntu1404_security_group_rules.tf
+++ b/terraform/vuln_ubuntu1404_security_group_rules.tf
@@ -1,0 +1,63 @@
+# Allow ingress from trusted networks on all TCP ports
+resource "aws_security_group_rule" "ubuntu1404_ingress_all_tcp_from_trusted" {
+  security_group_id = "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  type = "ingress"
+  protocol = "tcp"
+  cidr_blocks = "${var.trusted_ingress_networks_ipv4}"
+  # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
+  from_port = 0
+  to_port = 65535
+}
+
+# Allow ingress from trusted networks on all UDP ports
+resource "aws_security_group_rule" "ubuntu1404_ingress_all_udp_from_trusted" {
+  security_group_id = "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  type = "ingress"
+  protocol = "udp"
+  cidr_blocks = "${var.trusted_ingress_networks_ipv4}"
+  # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
+  from_port = 0
+  to_port = 65535
+}
+
+# Allow ingress from trusted networks for all ICMP
+resource "aws_security_group_rule" "ubuntu1404_ingress_all_icmp_from_trusted" {
+  security_group_id = "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  type = "ingress"
+  protocol = "icmp"
+  cidr_blocks = "${var.trusted_ingress_networks_ipv4}"
+  from_port = -1
+  to_port = -1
+}
+
+# Allow egress to trusted networks on all TCP ports
+resource "aws_security_group_rule" "ubuntu1404_egress_all_tcp_from_trusted" {
+  security_group_id = "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  type = "egress"
+  protocol = "tcp"
+  cidr_blocks = "${var.trusted_ingress_networks_ipv4}"
+  # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
+  from_port = 0
+  to_port = 65535
+}
+
+# Allow egress to trusted networks on all UDP ports
+resource "aws_security_group_rule" "ubuntu1404_egress_all_udp_from_trusted" {
+  security_group_id = "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  type = "egress"
+  protocol = "udp"
+  cidr_blocks = "${var.trusted_ingress_networks_ipv4}"
+  # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
+  from_port = 0
+  to_port = 65535
+}
+
+# Allow egress to trusted networks for all ICMP
+resource "aws_security_group_rule" "ubuntu1404_egress_all_icmp_from_trusted" {
+  security_group_id = "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  type = "egress"
+  protocol = "icmp"
+  cidr_blocks = "${var.trusted_ingress_networks_ipv4}"
+  from_port = -1
+  to_port = -1
+}


### PR DESCRIPTION
This PR is enough to get a single vulnerable instance of Ubuntu 14.04 (based off of an AMI created from [this packer file](https://github.com/cisagov/metasploitable3/blob/master/packer/templates/aws/ubuntu_1404.json)) spun up in an AWS VPC with the following setup:
- Single subnet containing the vulnerable Ubuntu instance
- ACLs to restrict access to IPs in trusted networks (via `trusted_ingress_networks_ipv4` variable)
- SSH access restricted to the NCATS OIS team (via `terraform/scripts/user_ssh_setup.yml`)

This is a quick and dirty setup that will be refined later.

Note: The Ubuntu instance is currently set up as a `t2.micro` because the AWS 't3' instances require the [Elastic Network Adapter](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena.html) and I didn't want to delay delivery of the instance for this.