### PR TITLE
Update for use with Terraform 0.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,49 @@
+---
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
     hooks:
-    -   id: check-json
-    -   id: check-yaml
-    -   id: debug-statements
-    -   id: detect-aws-credentials
-    -   id: end-of-file-fixer
-        exclude: ^docs/.*$
-    -   id: trailing-whitespace
-        exclude: README.md
-    -   id: pretty-format-json
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-xml
+      - id: debug-statements
+      - id: detect-aws-credentials
         args:
-        - --autofix
-    -   id: flake8
--   repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.11.0
+          - --allow-missing-credentials
+      - id: detect-private-key
+      - id: end-of-file-fixer
+        exclude: files/(issue|motd)
+      - id: mixed-line-ending
+        args:
+          - --fix=lf
+      - id: pretty-format-json
+        args:
+          - --autofix
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.16.0
     hooks:
-    - id: terraform_fmt
-    - id: terraform_docs
-    - id: terraform_validate_with_variables
-- repo: https://github.com/ansible/ansible-lint.git
-  rev: v4.1.0a0
-  hooks:
-    - id: ansible-lint
-      files: \.(yaml|yml)$
-- repo: https://github.com/jumanjihouse/pre-commit-hooks
-  sha: 1.11.0
-  hooks:
-    - id: markdownlint # Configure in .mdlrc
-      exclude: LICENSE.md
-    - id: shellcheck
+      - id: markdownlint
+        # The LICENSE.md must match the license text exactly for
+        # GitHub's autorecognition fu to work, so we should leave it
+        # alone.
+        exclude: LICENSE.md
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.15.0
+    hooks:
+      - id: yamllint
+  - repo: https://github.com/detailyang/pre-commit-shell
+    rev: 1.0.5
+    hooks:
+      - id: shell-lint
+  - repo: https://github.com/antonbabenko/pre-commit-terraform.git
+    rev: v1.12.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate_no_variables
+  - repo: https://github.com/prettier/prettier
+    rev: 1.17.1
+    hooks:
+      - id: prettier

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# Already being linted by mdl
+*.md
+# Already being linted by yamllint
+*.yaml
+*.yml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  # yamllint doesn't like when we use yes and no for true and false,
+  # but that's pretty standard in Ansible.
+  truthy: disable

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ and `tags` are correct in `packer/templates/aws/ubuntu_1404.json`.
 To build the AMI, run this command from the root directory of your clone of
 [cisagov/metasploitable3](https://github.com/cisagov/metasploitable3):
 
-```
+```bash
 packer build packer/templates/aws/ubuntu_1404.json
 ```
 
@@ -61,7 +61,7 @@ repository referenced above).
   `production.yml`), based on the variables listed in `terraform/variables.tf`.
   Here is a sample of what that file might look like:
 
-```
+```yaml
 aws_region = "us-east-1"
 
 aws_availability_zone = "a"
@@ -91,7 +91,7 @@ To create the environment containing the vulnerable instance(s), run the
 following terraform commands (replace `<your_workspace>` with a name like
 your username or "production"):
 
-```
+```bash
 cd terraform
 
 # If you have not created your terraform workspace:
@@ -109,7 +109,7 @@ terraform apply -var-file=<your_workspace>.yml
 To destroy the environment containing the vulnerable instance(s), run the
 following terraform commands:
 
-```
+```bash
 cd terraform
 terraform workspace select <your_workspace>
 terraform destroy -var-file=<your_workspace>.yml

--- a/terraform/acl_rules.tf
+++ b/terraform/acl_rules.tf
@@ -1,7 +1,7 @@
 # Allow ingress from anywhere via any protocol and port
 # Restrictions by source IP are handled by the security group rules
 resource "aws_network_acl_rule" "ingress_from_anywhere_via_any_port" {
-  network_acl_id = "${aws_network_acl.vuln_acl.id}"
+  network_acl_id = aws_network_acl.vuln_acl.id
   egress         = false
   protocol       = "-1"
   rule_number    = 100
@@ -14,7 +14,7 @@ resource "aws_network_acl_rule" "ingress_from_anywhere_via_any_port" {
 # Allow egress to anywhere via any protocol and port
 # Restrictions by source IP are handled by the security group rules
 resource "aws_network_acl_rule" "egress_to_anywhere_via_any_port" {
-  network_acl_id = "${aws_network_acl.vuln_acl.id}"
+  network_acl_id = aws_network_acl.vuln_acl.id
   egress         = true
   protocol       = "-1"
   rule_number    = 110

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,10 +1,12 @@
 # Configure AWS
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 # The AWS account ID being used
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 # The list of available AWS availability zones
-data "aws_availability_zones" "all" {}
+data "aws_availability_zones" "all" {
+}

--- a/terraform/scripts/user_ssh_setup.yml
+++ b/terraform/scripts/user_ssh_setup.yml
@@ -1,27 +1,31 @@
-#cloud-config
-
+# cloud-config
+---
 users:
   - name: mark.feldhousen
-    groups: [ sudo ]
-    sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
+    groups: [sudo]
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
     shell: /bin/bash
     ssh-authorized-keys:
+      # yamllint disable-line rule:line-length
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDMAreqS1aycngT1qQAsXfo7/hzt8JdSvC1bD9Sr0WpTUVWWe6WW2mYQ9fHAYJ4pPGb/Jf3h15NRMHCwsMPuFoP+9m7iebzvS47/ce1g07AOK3bf2yR12v/S9QFArgAyabqRpDz43yay2t+3IjSHxZlKKNg0nV4xiP/LRqXvzFCjZDAu5zslFH/urZ6bhHxQMywWdW0RHfWXdz+O6rGR8f1soCPw7ylwf2AzlaeCR/WnT9QiK5TG5TxrkomnliE56T0JkhldGrTldkt2NK1R9+3wF4603nQqKkcCgXFtZKk0wKc5T+Z/B/mS9LW0ayarj1V6H1i5mpscYOD33Z6HalEXd25XO31oCDt9FuA7pHOZQInTpvNODktjwkkz0Dk6i6q3b60JaviB5ECaC9bcQDfXFGVNzA/+UVtOIKOKmp7ge8n31jEEq6nklDxrVkA/7n7cKXjUTZbV5Lru+3of8lLdYCcJhcLLMDSmJbGtw7/AN55+vxj072pLs1LAUcDBlEtqq5rShUcFeFDuxl0Cs7BRab87h6nO/uIKTAb4ZNbAKt0BuKW2gzRoVjUhibMLc/loJyeZuWa67QQ8Ae76h24dPUz44Ryul/X5LHingGd3lwQMyW/0mjpVKjC0lsUsGa+J2wezsMzxr8sj9TjYzhMCURf79E6DBUO1zUuFc0kyw== mark.feldhousen
   - name: david.redmin
-    groups: [ sudo ]
-    sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
+    groups: [sudo]
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
     shell: /bin/bash
     ssh-authorized-keys:
+      # yamllint disable-line rule:line-length
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPCUrFIDwLAZrlkzvK7rcOVYNE7vSyopGHMFZTX7YlQS david.redmin
   - name: jeremy.frasier
-    groups: [ sudo ]
-    sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
+    groups: [sudo]
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
     shell: /bin/bash
     ssh-authorized-keys:
+      # yamllint disable-line rule:line-length
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHJkFgYx58vd/JCikIQRVmQUBNa5k1h9Z+xzM6AjZLqE jeremy.frasier
   - name: kyle.evers
-    groups: [ sudo ]
-    sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
+    groups: [sudo]
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
     shell: /bin/bash
     ssh-authorized-keys:
+      # yamllint disable-line rule:line-length
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKY5tqMRtnZSkVPwU0X1zKA8L3RnvmhSAR/bHAtd3Vcr kyle.evers

--- a/terraform/ssh_cloud_init.tf
+++ b/terraform/ssh_cloud_init.tf
@@ -1,7 +1,7 @@
 # cloud-init commands for configuring ssh
 
 data "template_file" "user_ssh_setup" {
-  template = "${file("scripts/user_ssh_setup.yml")}"
+  template = file("scripts/user_ssh_setup.yml")
 }
 
 data "template_cloudinit_config" "ssh_cloud_init_tasks" {
@@ -11,6 +11,6 @@ data "template_cloudinit_config" "ssh_cloud_init_tasks" {
   part {
     filename     = "user_ssh_setup.yml"
     content_type = "text/cloud-config"
-    content      = "${data.template_file.user_ssh_setup.rendered}"
+    content      = data.template_file.user_ssh_setup.rendered
   }
 }

--- a/terraform/ubuntu1404_ec2.tf
+++ b/terraform/ubuntu1404_ec2.tf
@@ -17,17 +17,17 @@ data "aws_ami" "metasploitable3_ubuntu1404" {
     values = ["ebs"]
   }
 
-  owners      = ["${data.aws_caller_identity.current.account_id}"] # This is us
+  owners      = [data.aws_caller_identity.current.account_id] # This is us
   most_recent = true
 }
 
 # The vulnerable Ubuntu 14.04 EC2 instance
 resource "aws_instance" "vuln_ubuntu1404" {
-  ami               = "${data.aws_ami.metasploitable3_ubuntu1404.id}"
+  ami               = data.aws_ami.metasploitable3_ubuntu1404.id
   instance_type     = "t2.micro"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
-  subnet_id                   = "${aws_subnet.vuln_subnet.id}"
+  subnet_id                   = aws_subnet.vuln_subnet.id
   associate_public_ip_address = true
 
   root_block_device {
@@ -37,11 +37,21 @@ resource "aws_instance" "vuln_ubuntu1404" {
   }
 
   vpc_security_group_ids = [
-    "${aws_security_group.vuln_ubuntu1404_sg.id}",
+    aws_security_group.vuln_ubuntu1404_sg.id,
   ]
 
-  user_data_base64 = "${data.template_cloudinit_config.ssh_cloud_init_tasks.rendered}"
+  user_data_base64 = data.template_cloudinit_config.ssh_cloud_init_tasks.rendered
 
-  tags        = "${merge(var.tags, map("Name", "Vulnerable Ubuntu 14.04"))}"
-  volume_tags = "${merge(var.tags, map("Name", "Vulnerable Ubuntu 14.04"))}"
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "Vulnerable Ubuntu 14.04"
+    },
+  )
+  volume_tags = merge(
+    var.tags,
+    {
+      "Name" = "Vulnerable Ubuntu 14.04"
+    },
+  )
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,7 +9,7 @@ variable "aws_availability_zone" {
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   description = "Tags to apply to all AWS resources created"
   default     = {}
 }
@@ -17,13 +17,13 @@ variable "tags" {
 # This should be overridden by a production.tfvars file,
 # most likely stored outside of version control
 variable "trusted_ingress_networks_ipv4" {
-  type        = "list"
+  type        = list(string)
   description = "IPv4 CIDR blocks from which to allow ingress to the bastion server"
   default     = ["0.0.0.0/0"]
 }
 
 variable "trusted_ingress_networks_ipv6" {
-  type        = "list"
+  type        = list(string)
   description = "IPv6 CIDR blocks from which to allow ingress to the bastion server"
   default     = ["::/0"]
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -2,59 +2,87 @@
 resource "aws_vpc" "vuln_vpc" {
   cidr_block = "10.10.10.0/28"
 
-  tags = "${merge(var.tags, map("Name", "Vulnerable VPC"))}"
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "Vulnerable VPC"
+    },
+  )
 }
 
 # Vulnerable (only) subnet of the VPC
 resource "aws_subnet" "vuln_subnet" {
-  vpc_id            = "${aws_vpc.vuln_vpc.id}"
+  vpc_id            = aws_vpc.vuln_vpc.id
   cidr_block        = "10.10.10.0/28"
   availability_zone = "${var.aws_region}${var.aws_availability_zone}"
 
-  depends_on = [
-    "aws_internet_gateway.vuln_igw",
-  ]
+  depends_on = [aws_internet_gateway.vuln_igw]
 
-  tags = "${merge(var.tags, map("Name", "Vulnerable Subnet"))}"
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "Vulnerable Subnet"
+    },
+  )
 }
 
 # The internet gateway for the VPC
 resource "aws_internet_gateway" "vuln_igw" {
-  vpc_id = "${aws_vpc.vuln_vpc.id}"
+  vpc_id = aws_vpc.vuln_vpc.id
 
-  tags = "${merge(var.tags, map("Name", "Vulnerable IGW"))}"
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "Vulnerable IGW"
+    },
+  )
 }
 
 # Default route table for VPC, which routes all external traffic
 # through the internet gateway
 resource "aws_default_route_table" "vuln_default_route_table" {
-  default_route_table_id = "${aws_vpc.vuln_vpc.default_route_table_id}"
+  default_route_table_id = aws_vpc.vuln_vpc.default_route_table_id
 
-  tags = "${merge(var.tags, map("Name", "Vulnerable Route Table"))}"
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "Vulnerable Route Table"
+    },
+  )
 }
 
 # Default route: Route all external traffic through the internet
 # gateway
 resource "aws_route" "vuln_default_route_external_traffic_through_internet_gateway" {
-  route_table_id         = "${aws_default_route_table.vuln_default_route_table.id}"
+  route_table_id         = aws_default_route_table.vuln_default_route_table.id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.vuln_igw.id}"
+  gateway_id             = aws_internet_gateway.vuln_igw.id
 }
 
 # ACL for the vulnerable (only) subnet
 resource "aws_network_acl" "vuln_acl" {
-  vpc_id = "${aws_vpc.vuln_vpc.id}"
+  vpc_id = aws_vpc.vuln_vpc.id
 
   subnet_ids = [
-    "${aws_subnet.vuln_subnet.id}",
+    aws_subnet.vuln_subnet.id,
   ]
 
-  tags = "${merge(var.tags, map("Name", "Vulnerable ACL"))}"
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "Vulnerable ACL"
+    },
+  )
 }
 
 # Security group for the vulnerable Ubuntu 14.04 instance
 resource "aws_security_group" "vuln_ubuntu1404_sg" {
-  vpc_id = "${aws_vpc.vuln_vpc.id}"
+  vpc_id = aws_vpc.vuln_vpc.id
 
-  tags = "${merge(var.tags, map("Name", "Vulnerable Ubuntu 14.04"))}"
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "Vulnerable Ubuntu 14.04"
+    },
+  )
 }

--- a/terraform/vuln_ubuntu1404_security_group_rules.tf
+++ b/terraform/vuln_ubuntu1404_security_group_rules.tf
@@ -1,9 +1,9 @@
 # Allow ingress from trusted networks on all TCP ports
 resource "aws_security_group_rule" "ubuntu1404_ingress_all_tcp_from_trusted" {
-  security_group_id = "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  security_group_id = aws_security_group.vuln_ubuntu1404_sg.id
   type              = "ingress"
   protocol          = "tcp"
-  cidr_blocks       = "${var.trusted_ingress_networks_ipv4}"
+  cidr_blocks       = var.trusted_ingress_networks_ipv4
 
   # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
   from_port = 0
@@ -12,10 +12,10 @@ resource "aws_security_group_rule" "ubuntu1404_ingress_all_tcp_from_trusted" {
 
 # Allow ingress from trusted networks on all UDP ports
 resource "aws_security_group_rule" "ubuntu1404_ingress_all_udp_from_trusted" {
-  security_group_id = "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  security_group_id = aws_security_group.vuln_ubuntu1404_sg.id
   type              = "ingress"
   protocol          = "udp"
-  cidr_blocks       = "${var.trusted_ingress_networks_ipv4}"
+  cidr_blocks       = var.trusted_ingress_networks_ipv4
 
   # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
   from_port = 0
@@ -24,20 +24,20 @@ resource "aws_security_group_rule" "ubuntu1404_ingress_all_udp_from_trusted" {
 
 # Allow ingress from trusted networks for all ICMP
 resource "aws_security_group_rule" "ubuntu1404_ingress_all_icmp_from_trusted" {
-  security_group_id = "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  security_group_id = aws_security_group.vuln_ubuntu1404_sg.id
   type              = "ingress"
   protocol          = "icmp"
-  cidr_blocks       = "${var.trusted_ingress_networks_ipv4}"
+  cidr_blocks       = var.trusted_ingress_networks_ipv4
   from_port         = -1
   to_port           = -1
 }
 
 # Allow egress to trusted networks on all TCP ports
 resource "aws_security_group_rule" "ubuntu1404_egress_all_tcp_from_trusted" {
-  security_group_id = "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  security_group_id = aws_security_group.vuln_ubuntu1404_sg.id
   type              = "egress"
   protocol          = "tcp"
-  cidr_blocks       = "${var.trusted_ingress_networks_ipv4}"
+  cidr_blocks       = var.trusted_ingress_networks_ipv4
 
   # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
   from_port = 0
@@ -46,10 +46,10 @@ resource "aws_security_group_rule" "ubuntu1404_egress_all_tcp_from_trusted" {
 
 # Allow egress to trusted networks on all UDP ports
 resource "aws_security_group_rule" "ubuntu1404_egress_all_udp_from_trusted" {
-  security_group_id = "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  security_group_id = aws_security_group.vuln_ubuntu1404_sg.id
   type              = "egress"
   protocol          = "udp"
-  cidr_blocks       = "${var.trusted_ingress_networks_ipv4}"
+  cidr_blocks       = var.trusted_ingress_networks_ipv4
 
   # ipv6_cidr_blocks = "${var.trusted_ingress_networks_ipv6}"
   from_port = 0
@@ -58,10 +58,10 @@ resource "aws_security_group_rule" "ubuntu1404_egress_all_udp_from_trusted" {
 
 # Allow egress to trusted networks for all ICMP
 resource "aws_security_group_rule" "ubuntu1404_egress_all_icmp_from_trusted" {
-  security_group_id = "${aws_security_group.vuln_ubuntu1404_sg.id}"
+  security_group_id = aws_security_group.vuln_ubuntu1404_sg.id
   type              = "egress"
   protocol          = "icmp"
-  cidr_blocks       = "${var.trusted_ingress_networks_ipv4}"
+  cidr_blocks       = var.trusted_ingress_networks_ipv4
   from_port         = -1
   to_port           = -1
 }


### PR DESCRIPTION
This PR makes all of our pre-commit checks up-to-date with the [skeleton-generic](https://github.com/cisagov/skeleton-generic) project and it fixes some errors related to those pre-commit checks.

It also includes all of the changes from running `terraform 0.12upgrade`.