### PR TITLE
Upgrade the root volume type to gp3

### DIFF
--- a/terraform/ubuntu1404_ec2.tf
+++ b/terraform/ubuntu1404_ec2.tf
@@ -31,9 +31,8 @@ resource "aws_instance" "vuln_ubuntu1404" {
   associate_public_ip_address = true
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = 100
-    delete_on_termination = true
+    volume_size = 100
+    volume_type = "gp3"
   }
 
   vpc_security_group_ids = [


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Upgrades the root volume type to gp3
- Removes the `delete_on_termination` line

## 💭 Motivation and context ##

gp3 is 20% cheaper, and the baseline configuration offers better performance than gp2 for volumes smaller than 2TB.  It also allows the volume size and IOPS to be configured separately, whereas the two are intertwined with gp2.

Since `delete_on_termination = true` is the default, so there is no need to specify it.

## 🧪 Testing ##

See cisagov/cool-assessment-terraform#148 for an example of how I tested identical changes in another repository.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
